### PR TITLE
Add flake8 checks and more Python versions for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,9 @@ matrix:
 # To install dependencies, tell tox to do everything but actually running the
 # test.
 install:
-    - travis_retry pip install tox
-    - travis_retry tox --notest
+    - travis_retry python setup.py test -a "--notest"
 
-script: tox
+script: python setup.py test
 
 # Report coverage to codecov.io.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,43 @@
 language: python
-python:
-    - "2.7"
-    - "3.3"
-    - "3.4"
-    - "pypy"
-
-install:
-    - pip install .
-
-script: nosetests --with-coverage --cover-package=confuse
-
-# coveralls.io reporting, using https://github.com/coagulant/coveralls-python
-# Only report coverage for one version.
-before_script:
-    - "[[ $TRAVIS_PYTHON_VERSION == '3.3' ]] && pip install coveralls || true"
-after_success:
-    - "[[ $TRAVIS_PYTHON_VERSION == '3.3' ]] && coveralls || true"
-
 sudo: false
+
+env:
+    global:
+        # Undocumented feature of nose-show-skipped.
+        NOSE_SHOW_SKIPPED: 1
+
+matrix:
+    include:
+        - python: 2.7
+          env: {TOXENV: py27-test}
+        - python: 3.3
+          env: {TOXENV: py33-cov, COVERAGE: 1}
+        - python: 3.4
+          env: {TOXENV: py34-test}
+        - python: 3.5
+          env: {TOXENV: py35-test}
+        - python: pypy
+          env: {TOXENV: pypy-test}
+        - python: 2.7
+          env: {TOXENV: py27-flake8}
+        - python: 3.3
+          env: {TOXENV: py33-flake8}
+        - python: 2.7
+          env: {TOXENV: docs}
+
+# To install dependencies, tell tox to do everything but actually running the
+# test.
+install:
+    - travis_retry pip install tox
+    - travis_retry tox --notest
+
+script: tox
+
+# Report coverage to codecov.io.
+before_install:
+    - "[ ! -z $COVERAGE ] && travis_retry pip install codecov || true"
+after_success:
+    - "[ ! -z $COVERAGE ] && codecov || true"
+
+cache:
+    pip: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+# Don't post a comment on pull requests.
+comment: off
+
+# I think this disables commit statuses?
+coverage:
+    status:
+        project:
+            enabled: no
+        patch:
+            enabled: no
+        changes:
+            enabled: no

--- a/confuse.py
+++ b/confuse.py
@@ -26,6 +26,7 @@ import collections
 import re
 from collections import OrderedDict
 
+
 UNIX_DIR_VAR = 'XDG_CONFIG_HOME'
 UNIX_DIR_FALLBACK = '~/.config'
 WINDOWS_DIR_VAR = 'APPDATA'

--- a/confuse.py
+++ b/confuse.py
@@ -45,9 +45,9 @@ REDACTED_TOMBSTONE = 'REDACTED'
 # Utilities.
 
 PY3 = sys.version_info[0] == 3
-STRING = str if PY3 else unicode
-BASESTRING = str if PY3 else basestring
-NUMERIC_TYPES = (int, float) if PY3 else (int, float, long)
+STRING = str if PY3 else unicode  # noqa ignore=F821
+BASESTRING = str if PY3 else basestring  # noqa ignore=F821
+NUMERIC_TYPES = (int, float) if PY3 else (int, float, long)  # noqa ignore=F821
 
 
 def iter_first(sequence):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,5 +18,4 @@ pygments_style = 'sphinx'
 # -- Options for HTML output --------------------------------------------------
 
 html_theme = 'default'
-html_static_path = ['_static']
 htmlhelp_basename = 'Confusedoc'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+from __future__ import division, absolute_import, print_function
+
+
 extensions = []
 source_suffix = '.rst'
 master_doc = 'index'
@@ -12,7 +15,7 @@ exclude_patterns = ['_build']
 
 pygments_style = 'sphinx'
 
-# -- Options for HTML output ---------------------------------------------------
+# -- Options for HTML output --------------------------------------------------
 
 html_theme = 'default'
 html_static_path = ['_static']

--- a/example.py
+++ b/example.py
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
 import example
+
 example.main()

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -1,8 +1,8 @@
 """An example application using Confuse for configuration."""
-from __future__ import print_function
-from __future__ import unicode_literals
+from __future__ import division, absolute_import, print_function
 import confuse
 import argparse
+
 
 template = {
     'library': confuse.Filename(),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[nosetests]
+verbosity=1
+logging-clear-handlers=1
+eval-attr="!=slow"
+
+[flake8]
+min-version=2.7
+# Default pyflakes errors we ignore:
+# - E241: missing whitespace after ',' (used to align visually)
+# - E221: multiple spaces before operator (used to align visually)
+# - E731: do not assign a lambda expression, use a def
+# - C901: function/method complexity
+# `flake8-future-import` errors we ignore:
+# - FI50: `__future__` import "division" present
+# - FI51: `__future__` import "absolute_import" present
+# - FI12: `__future__` import "with_statement" missing
+# - FI53: `__future__` import "print_function" present
+# - FI14: `__future__` import "unicode_literals" missing
+# - FI15: `__future__` import "generator_stop" missing
+ignore=C901,E241,E221,E731,FI50,FI51,FI12,FI53,FI14,FI15

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,63 @@
-from setuptools import setup
+from __future__ import division, absolute_import, print_function
+
 import os
+from os import path
+import sys
+from setuptools.dist import Distribution
+from setuptools import setup, Command
+
+
+class CustomDistribution(Distribution):
+    def __init__(self, *args, **kwargs):
+        self.sdist_requires = None
+        Distribution.__init__(self, *args, **kwargs)
+
+    def get_finalized_command(self, command, create=1):
+        cmd_obj = self.get_command_obj(command, create)
+        cmd_obj.ensure_finalized()
+        return cmd_obj
+
+    def export_live_eggs(self, env=False):
+        """Adds all of the eggs in the current environment to PYTHONPATH."""
+        path_eggs = [p for p in sys.path if p.endswith('.egg')]
+
+        command = self.get_finalized_command("egg_info")
+        egg_base = path.abspath(command.egg_base)
+
+        unique_path_eggs = set(path_eggs + [egg_base])
+
+        os.environ['PYTHONPATH'] = ':'.join(unique_path_eggs)
+
+
+class test(Command):  # noqa: ignore=N801
+    """Command to run tox."""
+
+    description = "run tox tests"
+
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        self.tox_args = ''
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        # Install test dependencies if needed.
+        if self.distribution.tests_require:
+            self.distribution.fetch_build_eggs(self.distribution.tests_require)
+
+        # Add eggs to PYTHONPATH. We need to do this to ensure our eggs are
+        # seen by Tox.
+        self.distribution.export_live_eggs()
+
+        shlex = __import__('shlex')
+        tox = __import__('tox')
+
+        parsed_args = shlex.split(self.tox_args)
+        result = tox.cmdline(args=parsed_args)
+
+        sys.exit(result)
 
 
 def _read(fn):
@@ -17,10 +75,10 @@ setup(
     license='MIT',
     platforms='ALL',
     long_description=_read("README.rst"),
-    install_requires=[
-        'pyyaml'
-    ],
+    install_requires=['pyyaml'],
+    tests_require=['tox'],
     py_modules=['confuse'],
+    cmdclass={'test': test},
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
@@ -30,4 +88,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
+    distclass=CustomDistribution
 )

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from os import path
 import sys
 from setuptools.dist import Distribution
 from setuptools import setup, Command
+import shlex
 
 
 class CustomDistribution(Distribution):
@@ -52,7 +53,6 @@ class test(Command):  # noqa: ignore=N801
         # Without this, Tox can't find it's dependencies.
         self.distribution.export_live_eggs()
 
-        shlex = __import__('shlex')
         tox = __import__('tox')
 
         parsed_args = shlex.split(self.tox_args)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ class test(Command):  # noqa: ignore=N801
 
         # Add eggs to PYTHONPATH. We need to do this to ensure our eggs are
         # seen by Tox.
+        # Without this, Tox can't find it's dependencies.
         self.distribution.export_live_eggs()
 
         shlex = __import__('shlex')

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import tempfile
 import shutil

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import argparse
 import optparse
@@ -36,6 +38,7 @@ class ArgparseTest(unittest.TestCase):
         self._parse('--foo bar')
         self.assertEqual(self.config['foo'].get(), 'bar')
 
+
 class OptparseTest(unittest.TestCase):
     def setUp(self):
         self.config = confuse.Configuration('test', read=False)
@@ -68,9 +71,11 @@ class OptparseTest(unittest.TestCase):
         self._parse('--foo bar')
         self.assertEqual(self.config['foo'].get(), 'bar')
 
+
 class Namespace(object):
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
+
 
 class GenericNamespaceTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_dump.py
+++ b/test/test_dump.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import textwrap
 import unittest

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import ntpath
 import os
@@ -7,10 +9,12 @@ import shutil
 import tempfile
 import unittest
 
+
 DEFAULT = [platform.system, os.environ, os.path]
+
 SYSTEMS = {
     'Linux': [{'HOME': '/home/test', 'XDG_CONFIG_HOME': '~/xdgconfig'},
-        posixpath],
+              posixpath],
     'Darwin': [{'HOME': '/Users/test'}, posixpath],
     'Windows': [{'APPDATA': '~\\winconfig', 'HOME': 'C:\\Users\\test'}, ntpath]
 }
@@ -48,7 +52,7 @@ class LinuxTestCases(FakeSystem):
 
     def test_both_xdg_and_fallback_dirs(self):
         self.assertEqual(confuse.config_dirs(),
-            ['/home/test/.config', '/home/test/xdgconfig'])
+                         ['/home/test/.config', '/home/test/xdgconfig'])
 
     def test_fallback_only(self):
         del os.environ['XDG_CONFIG_HOME']
@@ -64,7 +68,8 @@ class OSXTestCases(FakeSystem):
 
     def test_mac_dirs(self):
         self.assertEqual(confuse.config_dirs(),
-            ['/Users/test/Library/Application Support', '/Users/test/.config'])
+                         ['/Users/test/Library/Application Support',
+                          '/Users/test/.config'])
 
 
 class WindowsTestCases(FakeSystem):
@@ -72,13 +77,13 @@ class WindowsTestCases(FakeSystem):
 
     def test_dir_from_environ(self):
         self.assertEqual(confuse.config_dirs(),
-            ['C:\\Users\\test\\AppData\\Roaming',
-            'C:\\Users\\test\\winconfig'])
+                         ['C:\\Users\\test\\AppData\\Roaming',
+                          'C:\\Users\\test\\winconfig'])
 
     def test_fallback_dir(self):
         del os.environ['APPDATA']
         self.assertEqual(confuse.config_dirs(),
-            ['C:\\Users\\test\\AppData\\Roaming'])
+                         ['C:\\Users\\test\\AppData\\Roaming'])
 
 
 class ConfigFilenamesTest(unittest.TestCase):

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -107,13 +107,13 @@ class AsTemplateTest(unittest.TestCase):
 
     @unittest.skipIf(confuse.PY3, "unicode only present in Python 2")
     def test_unicode_type_as_template(self):
-        typ = confuse.as_template(unicode)
+        typ = confuse.as_template(unicode)  # noqa ignore=F821
         self.assertIsInstance(typ, confuse.String)
         self.assertEqual(typ.default, confuse.REQUIRED)
 
     @unittest.skipIf(confuse.PY3, "basestring only present in Python 2")
     def test_basestring_as_template(self):
-        typ = confuse.as_template(basestring)
+        typ = confuse.as_template(basestring)  # noqa ignore=F821
         self.assertIsInstance(typ, confuse.String)
         self.assertEqual(typ.default, confuse.REQUIRED)
 

--- a/test/test_valid.py
+++ b/test/test_valid.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import os
 import collections
@@ -375,7 +377,7 @@ class FilenameTest(unittest.TestCase):
 
     def test_filename_with_file_source(self):
         source = confuse.ConfigSource({'foo': 'foo/bar'},
-                                     filename='/baz/config.yaml')
+                                      filename='/baz/config.yaml')
         config = _root(source)
         config.config_dir = lambda: '/config/path'
         valid = config['foo'].get(confuse.Filename())
@@ -383,8 +385,8 @@ class FilenameTest(unittest.TestCase):
 
     def test_filename_with_default_source(self):
         source = confuse.ConfigSource({'foo': 'foo/bar'},
-                                     filename='/baz/config.yaml',
-                                     default=True)
+                                      filename='/baz/config.yaml',
+                                      default=True)
         config = _root(source)
         config.config_dir = lambda: '/config/path'
         valid = config['foo'].get(confuse.Filename())

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -84,7 +84,7 @@ class BuiltInValidatorTest(unittest.TestCase):
 
     @unittest.skipIf(confuse.PY3, "long only present in Python 2")
     def test_as_number_long_in_py2(self):
-        config = _root({'l': long(3)})
+        config = _root({'l': long(3)})  # noqa ignore=F821
         config['l'].as_number()
 
     def test_as_number_string(self):

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import os
 import unittest
@@ -34,7 +36,7 @@ class BuiltInValidatorTest(unittest.TestCase):
 
     def test_as_filename_with_file_source(self):
         source = confuse.ConfigSource({'foo': 'foo/bar'},
-                                     filename='/baz/config.yaml')
+                                      filename='/baz/config.yaml')
         config = _root(source)
         config.config_dir = lambda: '/config/path'
         value = config['foo'].as_filename()
@@ -42,8 +44,8 @@ class BuiltInValidatorTest(unittest.TestCase):
 
     def test_as_filename_with_default_source(self):
         source = confuse.ConfigSource({'foo': 'foo/bar'},
-                                     filename='/baz/config.yaml',
-                                     default=True)
+                                      filename='/baz/config.yaml',
+                                      default=True)
         config = _root(source)
         config.config_dir = lambda: '/config/path'
         value = config['foo'].as_filename()

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -79,8 +79,8 @@ class ConverstionTest(unittest.TestCase):
     @unittest.skipIf(confuse.PY3, "unicode only present in Python 2")
     def test_unicode_conversion_from_int(self):
         config = _root({'foo': 2})
-        value = unicode(config['foo'])
-        self.assertEqual(value, unicode('2'))
+        value = unicode(config['foo'])  # noqa ignore=F821
+        self.assertEqual(value, unicode('2'))  # noqa ignore=F821
 
     def test_bool_conversion_from_bool(self):
         config = _root({'foo': True})

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import sys
 import unittest

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -1,3 +1,5 @@
+from __future__ import division, absolute_import, print_function
+
 import confuse
 import yaml
 import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,42 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
 [tox]
-envlist = py27, py34, pypy
+envlist = py27-test, py27-flake8, docs
+
+# The exhaustive list of environments is:
+# envlist = py{27,33,34,35}-{test,cov}, py{27,33}-flake8, docs
+
+[_test]
+deps =
+    coverage
+    nose
+    nose-show-skipped
+    pyyaml
+
+
+[_flake8]
+deps =
+    flake8
+    flake8-future-import
+    pep8-naming
+files = example confuse.py test setup.py docs
 
 [testenv]
+passenv =
+    NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
+deps =
+    {test,cov}: {[_test]deps}
+    py{27,33}-flake8: {[_flake8]deps}
 commands =
-    nosetests
-deps =
-    nose
+    cov: nosetests --with-coverage {posargs}
+    test: nosetests {posargs}
+    py27-flake8: flake8 --min-version 2.7 {posargs} {[_flake8]files}
+    py33-flake8: flake8 --min-version 3.3 {posargs} {[_flake8]files}
 
-[testenv:py27]
-deps =
-    {[testenv]deps}
-    argparse
+[testenv:docs]
+basepython = python2.7
+deps = sphinx
+commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27-test, py27-flake8, docs
-
-# The exhaustive list of environments is:
-# envlist = py{27,33,34,35}-{test,cov}, py{27,33}-flake8, docs
+envlist = py{27,33,34,35}-{test,cov}, py{27,33}-flake8, docs
 
 [_test]
 deps =


### PR DESCRIPTION
This is mainly based off beetbox/beets#2040 but without the `setup.py` changes (i.e. just `tox.ini`, `.travis.yml` and `setup.cfg`).

It adds tests for Python 3.5 and building docs, as well as running `flake8` on the code.

Currently the `flake8` tests are failing due to `flake8-future-import`, do you think we should keep this or just get rid of it? The reason I copied the beets configuration is mainly for code consistency (although admittedly confuse is not specifically for beets).

There's also one line too long in `docs/conf.py`.