### PR TITLE
Fix unicode reading errors in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,10 @@ class test(Command):  # noqa: ignore=N801
 
 def _read(fn):
     path = os.path.join(os.path.dirname(__file__), fn)
-    return open(path).read()
+    with open(path, "rb") as f:
+        data = f.read()
+
+    return data.decode("utf-8")
 
 
 setup(


### PR DESCRIPTION
setup.py uses a reading function which can fail if README.rst contains
non-ASCII characters. Fix it so that setup.py reads README.rst as data
then decodes as utf-8.
---
Essentially I was seeing this on a container install of confuse:
```
[root@3c6a3f7bb098 codebase]# locale
LANG=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
[root@3c6a3f7bb098 codebase]# python3 setup.py
Traceback (most recent call last):
  File "setup.py", line 78, in <module>
    long_description=_read("README.rst"),
  File "setup.py", line 66, in _read
    return open(path).read()
  File "/usr/lib64/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 382: ordinal not in range(128)
[root@3c6a3f7bb098 codebase]#
```
This is due to README.rst containing unicode characters. The fix just reads the file as bytes and then decodes those bytes as utf-8, in the standard Python 3 way.