### PR TITLE
default variable is not declared in Choice

### DIFF
--- a/confuse.py
+++ b/confuse.py
@@ -1223,7 +1223,7 @@ class String(Template):
 class Choice(Template):
     """A template that permits values from a sequence of choices.
     """
-    def __init__(self, choices):
+    def __init__(self, choices, default=REQUIRED):
         """Create a template that validates any of the values from the
         iterable `choices`.
 
@@ -1233,6 +1233,7 @@ class Choice(Template):
         If `choices` is a `Enum`, then the enum entry with the value is
         emitted.
         """
+        super(Choice, self).__init__(default)
         self.choices = choices
 
     def convert(self, value, view):


### PR DESCRIPTION
This fixes the following issue:
```
>>> import confuse
>>> config = confuse.Configuration('test')
>>> config.as_choice([1,2,3])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "D:\virtualenvs\confuse\lib\site-packages\confuse-0.5.0-py3.6.egg\confuse.py", line 491, in as_choice
    return self.get(Choice(choices))
  File "D:\virtualenvs\confuse\lib\site-packages\confuse-0.5.0-py3.6.egg\confuse.py", line 478, in get
    return as_template(template).value(self, template)
  File "D:\virtualenvs\confuse\lib\site-packages\confuse-0.5.0-py3.6.egg\confuse.py", line 1092, in value
    elif self.default is REQUIRED:
AttributeError: 'Choice' object has no attribute 'default'
```
Choice did not call `super().__init__()` to declare the `default` variable.