### PR TITLE
Add XDG_CONFIG_DIRS fallback

### DIFF
--- a/confuse.py
+++ b/confuse.py
@@ -662,10 +662,12 @@ def xdg_config_dirs():
     and XDG_CONFIG_HOME environment varibables if they exist
     """
     paths = []
-    if 'XDG_CONFIG_DIRS' in os.environ:
-        paths.extend(os.environ['XDG_CONFIG_DIRS'].split(':'))
     if 'XDG_CONFIG_HOME' in os.environ:
         paths.append(os.environ['XDG_CONFIG_HOME'])
+    if 'XDG_CONFIG_DIRS' in os.environ:
+        paths.extend(os.environ['XDG_CONFIG_DIRS'].split(':'))
+    else:
+        paths.extend(['/etc/xdg', '/etc'])
     return paths
 
 
@@ -953,11 +955,14 @@ class Configuration(RootView):
 
         else:
             # Search platform-specific locations. If no config file is
-            # found, fall back to the final directory in the list.
-            for confdir in config_dirs():
+            # found, fall back to the first directory in the list.
+            configdirs = config_dirs()
+            for confdir in configdirs:
                 appdir = os.path.join(confdir, self.appname)
                 if os.path.isfile(os.path.join(appdir, CONFIG_FILENAME)):
                     break
+            else:
+                appdir = os.path.join(configdirs[0], self.appname)
 
         # Ensure that the directory exists.
         if not os.path.isdir(appdir):

--- a/confuse.py
+++ b/confuse.py
@@ -667,7 +667,8 @@ def xdg_config_dirs():
     if 'XDG_CONFIG_DIRS' in os.environ:
         paths.extend(os.environ['XDG_CONFIG_DIRS'].split(':'))
     else:
-        paths.extend(['/etc/xdg', '/etc'])
+        paths.append('/etc/xdg')
+    paths.append('/etc')
     return paths
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -211,9 +211,13 @@ application called ``AppName``.
 Here are the default search paths for each platform:
 
 * OS X: ``~/.config/app`` and ``~/Library/Application Support/app``
-* Other Unix: ``$XDG_CONFIG_HOME/app`` and ``~/.config/app``
+* Other Unix: ``~/.config/app`` and ``/etc/app``
 * Windows: ``%APPDATA%\app`` where the `APPDATA` environment variable falls
   back to ``%HOME%\AppData\Roaming`` if undefined
+
+Both OS X and other Unix operating sytems also try to use the
+``XDG_CONFIG_HOME`` and ``XDG_CONFIG_DIRS`` environment variables if set
+then search those directories as well.
 
 Users can also add an override configuration directory with an
 environment variable. The variable name is the application name in

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -52,22 +52,25 @@ class LinuxTestCases(FakeSystem):
 
     def test_both_xdg_and_fallback_dirs(self):
         self.assertEqual(confuse.config_dirs(),
-                         ['/home/test/.config', '/home/test/xdgconfig'])
+                         ['/home/test/.config', '/home/test/xdgconfig',
+                          '/etc/xdg', '/etc'])
 
     def test_fallback_only(self):
         del os.environ['XDG_CONFIG_HOME']
-        self.assertEqual(confuse.config_dirs(), ['/home/test/.config'])
+        self.assertEqual(confuse.config_dirs(), ['/home/test/.config',
+                                                 '/etc/xdg', '/etc'])
 
     def test_xdg_matching_fallback_not_duplicated(self):
         os.environ['XDG_CONFIG_HOME'] = '~/.config'
-        self.assertEqual(confuse.config_dirs(), ['/home/test/.config'])
+        self.assertEqual(confuse.config_dirs(), ['/home/test/.config',
+                                                 '/etc/xdg', '/etc'])
 
     def test_xdg_config_dirs(self):
         os.environ['XDG_CONFIG_DIRS'] = '/usr/local/etc/xdg:/etc/xdg'
         self.assertEqual(confuse.config_dirs(), ['/home/test/.config',
+                                                 '/home/test/xdgconfig',
                                                  '/usr/local/etc/xdg',
-                                                 '/etc/xdg',
-                                                 '/home/test/xdgconfig'])
+                                                 '/etc/xdg'])
 
 
 class OSXTestCases(FakeSystem):
@@ -76,7 +79,7 @@ class OSXTestCases(FakeSystem):
     def test_mac_dirs(self):
         self.assertEqual(confuse.config_dirs(),
                          ['/Users/test/Library/Application Support',
-                          '/Users/test/.config'])
+                          '/Users/test/.config', '/etc/xdg', '/etc'])
 
     def test_xdg_config_dirs(self):
         os.environ['XDG_CONFIG_DIRS'] = '/usr/local/etc/xdg:/etc/xdg'
@@ -180,7 +183,7 @@ class PrimaryConfigDirTest(FakeSystem):
             os.makedirs = self._makedirs
 
     def test_create_dir_if_none_exists(self):
-        path = os.path.join(self.home, 'xdgconfig', 'test')
+        path = os.path.join(self.home, '.config', 'test')
         assert not os.path.exists(path)
 
         self.assertEqual(self.config.config_dir(), path)

--- a/test/test_paths.py
+++ b/test/test_paths.py
@@ -70,7 +70,7 @@ class LinuxTestCases(FakeSystem):
         self.assertEqual(confuse.config_dirs(), ['/home/test/.config',
                                                  '/home/test/xdgconfig',
                                                  '/usr/local/etc/xdg',
-                                                 '/etc/xdg'])
+                                                 '/etc/xdg', '/etc'])
 
 
 class OSXTestCases(FakeSystem):
@@ -87,7 +87,7 @@ class OSXTestCases(FakeSystem):
                          ['/Users/test/Library/Application Support',
                           '/Users/test/.config',
                           '/usr/local/etc/xdg',
-                          '/etc/xdg'])
+                          '/etc/xdg', '/etc'])
 
 
 class WindowsTestCases(FakeSystem):


### PR DESCRIPTION
Add fallback directories if the `XDG_CONFIG_DIRS` is not set. The `/etc/xdg` fallback is part of the XDG Specification and I added `/etc` because it is the more common configuration directory.

I also changed the `Configuration.config_dir()` to fallback to the first directory in the list instead of the last. This was because the last directory is now either whatever `XDG_CONFIG_DIRS` or the new fallback which are normally directories you need root to create.

The test have been updated to reflect this change.

Signed-off-by: Nicholas Malcolm <bubylou7@gmail.com>