### PR TITLE
Remove deprecated imports from collections

### DIFF
--- a/confuse.py
+++ b/confuse.py
@@ -30,9 +30,12 @@ import os
 import pkgutil
 import sys
 import yaml
-import collections
 import re
 from collections import OrderedDict
+if sys.version_info >= (3, 3):
+    from collections import abc
+else:
+    import collections as abc
 
 UNIX_DIR_FALLBACK = '~/.config'
 WINDOWS_DIR_VAR = 'APPDATA'
@@ -1297,7 +1300,7 @@ class Choice(Template):
                 view
             )
 
-        if isinstance(self.choices, collections.Mapping):
+        if isinstance(self.choices, abc.Mapping):
             return self.choices[value]
         else:
             return value
@@ -1452,7 +1455,7 @@ class Filename(Template):
         return 'Filename({0})'.format(', '.join(args))
 
     def resolve_relative_to(self, view, template):
-        if not isinstance(template, (collections.Mapping, MappingTemplate)):
+        if not isinstance(template, (abc.Mapping, MappingTemplate)):
             # disallow config.get(Filename(relative_to='foo'))
             raise ConfigTemplateError(
                 u'relative_to may only be used when getting multiple values.'
@@ -1571,7 +1574,7 @@ def as_template(value):
     if isinstance(value, Template):
         # If it's already a Template, pass it through.
         return value
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, abc.Mapping):
         # Dictionaries work as templates.
         return MappingTemplate(value)
     elif value is int:
@@ -1595,9 +1598,9 @@ def as_template(value):
     elif value is None:
         return Template()
     elif value is dict:
-        return TypeTemplate(collections.Mapping)
+        return TypeTemplate(abc.Mapping)
     elif value is list:
-        return TypeTemplate(collections.Sequence)
+        return TypeTemplate(abc.Sequence)
     elif isinstance(value, type):
         return TypeTemplate(value)
     else:


### PR DESCRIPTION
Since Python 3.3 the abstract base classes from `collections` [are moved](https://docs.python.org/3/library/collections.abc.html) to the `collections.abc` module. From Python 3.8 they will be unavailable from their original location.