### PR TITLE
Port recent changes from confit

### DIFF
--- a/confuse.py
+++ b/confuse.py
@@ -495,11 +495,11 @@ class ConfigView(object):
         """
         return self.get(Number())
 
-    def as_str_seq(self):
+    def as_str_seq(self, split=True):
         """Get the value as a sequence of strings. Equivalent to
         `get(StrSeq())`.
         """
-        return self.get(StrSeq())
+        return self.get(StrSeq(split=split))
 
     def as_str(self):
         """Get the value as a (Unicode) string. Equivalent to

--- a/confuse.py
+++ b/confuse.py
@@ -769,7 +769,7 @@ def load_yaml(filename):
     parsed, a ConfigReadError is raised.
     """
     try:
-        with open(filename, 'r') as f:
+        with open(filename, 'rb') as f:
             return yaml.load(f, Loader=Loader)
     except (IOError, yaml.error.YAMLError) as exc:
         raise ConfigReadError(filename, exc)
@@ -1012,9 +1012,10 @@ class Configuration(RootView):
                 default_source = source
                 break
         if default_source and default_source.filename:
-            with open(default_source.filename, 'r') as fp:
+            with open(default_source.filename, 'rb') as fp:
                 default_data = fp.read()
-            yaml_out = restore_yaml_comments(yaml_out, default_data)
+            yaml_out = restore_yaml_comments(yaml_out,
+                                             default_data.decode('utf8'))
 
         return yaml_out
 

--- a/confuse.py
+++ b/confuse.py
@@ -889,7 +889,9 @@ class Configuration(RootView):
         super(Configuration, self).__init__([])
         self.appname = appname
         self.modname = modname
-        # Pre-resolve default source location
+
+        # Resolve default source location. We do this ahead of time to
+        # avoid unexpected problems if the working directory changes.
         self._package_path = _package_path(appname)
 
         self._env_var = '{0}DIR'.format(self.appname.upper())

--- a/confuse.py
+++ b/confuse.py
@@ -889,6 +889,8 @@ class Configuration(RootView):
         super(Configuration, self).__init__([])
         self.appname = appname
         self.modname = modname
+        # Pre-resolve default source location
+        self._package_path = _package_path(appname)
 
         self._env_var = '{0}DIR'.format(self.appname.upper())
 
@@ -917,9 +919,8 @@ class Configuration(RootView):
         `modname` if it was given.
         """
         if self.modname:
-            pkg_path = _package_path(self.modname)
-            if pkg_path:
-                filename = os.path.join(pkg_path, DEFAULT_FILENAME)
+            if self._package_path:
+                filename = os.path.join(self._package_path, DEFAULT_FILENAME)
                 if os.path.isfile(filename):
                     self.add(ConfigSource(load_yaml(filename), filename, True))
 

--- a/confuse.py
+++ b/confuse.py
@@ -1018,7 +1018,7 @@ class Configuration(RootView):
             with open(default_source.filename, 'rb') as fp:
                 default_data = fp.read()
             yaml_out = restore_yaml_comments(yaml_out,
-                                             default_data.decode('utf8'))
+                                             default_data.decode('utf-8'))
 
         return yaml_out
 

--- a/confuse.py
+++ b/confuse.py
@@ -892,7 +892,10 @@ class Configuration(RootView):
 
         # Resolve default source location. We do this ahead of time to
         # avoid unexpected problems if the working directory changes.
-        self._package_path = _package_path(appname)
+        if self.modname:
+            self._package_path = _package_path(self.modname)
+        else:
+            self._package_path = None
 
         self._env_var = '{0}DIR'.format(self.appname.upper())
 

--- a/confuse.py
+++ b/confuse.py
@@ -497,7 +497,7 @@ class ConfigView(object):
 
     def as_str_seq(self, split=True):
         """Get the value as a sequence of strings. Equivalent to
-        `get(StrSeq())`.
+        `get(StrSeq(split=split))`.
         """
         return self.get(StrSeq(split=split))
 

--- a/confuse.py
+++ b/confuse.py
@@ -51,9 +51,9 @@ REDACTED_TOMBSTONE = 'REDACTED'
 # Utilities.
 
 PY3 = sys.version_info[0] == 3
-STRING = str if PY3 else unicode  # noqa ignore=F821
-BASESTRING = str if PY3 else basestring  # noqa ignore=F821
-NUMERIC_TYPES = (int, float) if PY3 else (int, float, long)  # noqa ignore=F821
+STRING = str if PY3 else unicode  # noqa: F821
+BASESTRING = str if PY3 else basestring  # noqa: F821
+NUMERIC_TYPES = (int, float) if PY3 else (int, float, long)  # noqa: F821
 
 
 def iter_first(sequence):

--- a/confuse.py
+++ b/confuse.py
@@ -592,7 +592,7 @@ class Subview(ConfigView):
         if isinstance(self.key, int):
             self.name += u'#{0}'.format(self.key)
         elif isinstance(self.key, bytes):
-            self.name += self.key.decode('utf8')
+            self.name += self.key.decode('utf-8')
         elif isinstance(self.key, STRING):
             self.name += self.key
         else:
@@ -1386,7 +1386,7 @@ class StrSeq(Template):
 
     def convert(self, value, view):
         if isinstance(value, bytes):
-            value = value.decode('utf8', 'ignore')
+            value = value.decode('utf-8', 'ignore')
 
         if isinstance(value, STRING):
             if self.split:
@@ -1404,7 +1404,7 @@ class StrSeq(Template):
             if isinstance(x, STRING):
                 return x
             elif isinstance(x, bytes):
-                return x.decode('utf8', 'ignore')
+                return x.decode('utf-8', 'ignore')
             else:
                 self.fail(u'must be a list of strings', view, True)
         return list(map(convert, value))


### PR DESCRIPTION
This contains most of the commits that were added to `beets.util.confit` since the last evidence of synchronisation. The main change missing is the addition of the `Pairs` template there, which was a bigger patch and didn't apply cleanly.

The changes cause one test to fail but I'm not sure yet whether the test should be fixed or the relevant commit dropped since I'm not yet familiar with confuse.